### PR TITLE
aarch64: enable PAC and BTI

### DIFF
--- a/Asm/arm64/LzmaDecOpt.S
+++ b/Asm/arm64/LzmaDecOpt.S
@@ -10,6 +10,38 @@
 ; LzmaDec_DecodeReal_*() must be equal in both versions (C / ASM).
 */
 
+/*
+ ; AAarch64 PAC and BTI Support.
+ ;
+ ; Assembly:
+ ;  Since this code base has no indirect calls or jumps to any assembly,
+ ;  there is no need to modify the source code with bti or pac instructions.
+ ;
+ ; GNU Notes:
+ ;   BTI requires the GNU Elf notes section in order to be enabled. This is
+ ;   because linkers/loaders look at this section to determine page protections,
+ ;   specifically PROT_BTI when mapping in the instructions. PAC is a nice to
+ ;   have for auditing purposes. Note that unconditionally adding PAC and BTI here
+ ;   is OK since the linker will just discard the note for the produced linked
+ ;   object file.
+ */
+#if defined(__ELF__)
+  /* Define the property values for GNU notes section in ELF */
+  #define GNU_PROPERTY_AARCH64_BTI 0x1
+  #define GNU_PROPERTY_AARCH64_POINTER_AUTH 0x2
+
+  .pushsection .note.gnu.property, "a";
+  .balign 8;
+  .long 4;
+  .long 0x10;
+  .long 0x5;
+  .asciz "GNU";
+  .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+  .long 4;
+  .long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI);
+  .long 0;
+  .popsection;
+#endif
 
 #include "7zAsm.S"
 


### PR DESCRIPTION
Enable Pointer Authentication Codes (PAC) and Branch Target Identification (BTI) support for ARM 64 targets.

PAC works by signing the LR with either an A key or B key and verifying the return address. There are quite a few instructions capable of doing this, however, the Linux ARM ABI is to use hint compatible instructions that can be safely NOP'd on older hardware and can be assembled and linked with older binutils. This limits the instruction set to paciasp, pacibsp, autiasp and autibsp. Instructions prefixed with pac are for signing and instructions prefixed with aut are for signing. Both instructions are then followed with an a or b to indicate which signing key they are using. The keys can be controlled using -mbranch-protection=pac-ret for the A key and
-mbranch-protection=pac-ret+b-key for the B key.

BTI works by marking all call and jump positions with bti c and bti j instructions. If execution control transfers to an instruction other than a BTI instruction, the execution is killed via SIGILL. Note that to remove one instruction, the aforementioned pac instructions will also work as a BTI landing pad for bti c usages.

For BTI to work, all object files linked for a unit of execution, whether an executable or a library must have the GNU Notes section of the ELF file marked to indicate BTI support. This is so loader/linkers can apply the proper permission bits (PROT_BRI) on the memory region.

PAC can also be annotated in the GNU ELF notes section, but it's not required for enablement, as interleaved PAC and non-pac code works as expected since it's the callee that performs all the checking.