### PR TITLE
Clean up start Menu entry

### DIFF
--- a/C/Util/7zipInstall/7zipInstall.c
+++ b/C/Util/7zipInstall/7zipInstall.c
@@ -810,13 +810,6 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       continue;
 
     NormalizePrefix(link);
-    CatAscii(link, k_7zip);
-    // CatAscii(link, "2");
-    
-    if (i != 0)
-      MyCreateDir(link);
-    
-    NormalizePrefix(link);
     
     {
       unsigned baseLen = (unsigned)wcslen(link);
@@ -826,7 +819,6 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       {
         CpyAscii(link + baseLen, k == 0 ?
             "7-Zip File Manager.lnk" :
-            "7-Zip Help.lnk"
            );
         wcscpy(destPath, path);
         CatAscii(destPath, k == 0 ?

--- a/C/Util/7zipUninstall/7zipUninstall.c
+++ b/C/Util/7zipUninstall/7zipUninstall.c
@@ -394,7 +394,6 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       continue;
 
     NormalizePrefix(link);
-    CatAscii(link, "7-Zip\\");
     
     {
       const size_t baseLen = wcslen(link);
@@ -405,7 +404,6 @@ static void SetShellProgramsGroup(HWND hwndOwner)
       {
         CpyAscii(link + baseLen, k == 0 ?
             "7-Zip File Manager.lnk" :
-            "7-Zip Help.lnk");
         wcscpy(destPath, path);
         CatAscii(destPath, k == 0 ?
             "7zFM.exe" :


### PR DESCRIPTION
Cleans up the Windows Start Menu entry by removing the help link (this is not the right place to put it, and it is still findable under Apps & Programs) and placing the shortcut directly into the Start Menu, without a folder that requires a click to expand. This follows more modern practices and cleans up the UX a little.

I cannot find any documentation for contributing/building, please reach out if I did anything wrongly.