### PR TITLE
Memory Leak Detected in lib7zip When Parsing Malformed XZ Files

### DIFF
--- a/C/XzIn.c
+++ b/C/XzIn.c
@@ -117,10 +117,8 @@ static SRes Xz_ReadIndex2(CXzStream *p, const Byte *buf, size_t size, ISzAllocPt
     p->numBlocks = numBlocks;
     p->blocks = (CXzBlockSizes *)ISzAlloc_Alloc(alloc, sizeof(CXzBlockSizes) * numBlocks);
     if (!p->blocks)
-    {
-      Xz_Free(p, alloc);
       return SZ_ERROR_MEM;
-    }
+
     for (i = 0; i < numBlocks; i++)
     {
       CXzBlockSizes *block = &p->blocks[i];
@@ -147,7 +145,7 @@ static SRes Xz_ReadIndex2(CXzStream *p, const Byte *buf, size_t size, ISzAllocPt
     Xz_Free(p, alloc);
     return SZ_ERROR_ARCHIVE;
   }
-  
+
   return SZ_OK;
 }
 


### PR DESCRIPTION
Hi,

While testing malformed files, we identified a memory leak in lib7zip that occurs when the library fails to parse an XZ archive.

Please use the attached test file (test.xz) to reproduce and verify the issue.
[test.xz.zip](https://github.com/user-attachments/files/19488085/test.xz.zip)

Best regards,
Vitalii Sheludchenkov
