### PR TITLE
Fix non-standard Zip64 extended information fields being generated

### DIFF
--- a/CPP/7zip/Archive/Zip/ZipOut.cpp
+++ b/CPP/7zip/Archive/Zip/ZipOut.cpp
@@ -302,7 +302,7 @@ void COutArchive::WriteCentralHeader(const CItemOut &item)
 
   Write16((UInt16)item.Name.Len());
   
-  const UInt16 zip64ExtraSize = (UInt16)((isUnPack64 ? 8: 0) + (isPack64 ? 8: 0) + (isPosition64 ? 8: 0));
+  const UInt16 zip64ExtraSize = (UInt16)((isUnPack64 || isPack64 || isPosition64 ? 16: 0) + (isPosition64 ? 8: 0));
   const bool writeNtfs = item.Write_NtfsTime;
   const size_t centralExtraSize =
       (isZip64 ? 4 + zip64ExtraSize : 0)
@@ -330,10 +330,8 @@ void COutArchive::WriteCentralHeader(const CItemOut &item)
   {
     Write16(NFileHeader::NExtraID::kZip64);
     Write16(zip64ExtraSize);
-    if (isUnPack64)
-      Write64(item.Size);
-    if (isPack64)
-      Write64(item.PackSize);
+    Write64(item.Size);
+    Write64(item.PackSize);
     if (isPosition64)
       Write64(item.LocalHeaderPos);
   }


### PR DESCRIPTION
According to section "4.5.3 -Zip64 Extended Information Extra Field (0x0001)" of the Zip format specification (https://pkwaredownloads.blob.core.windows.net/pkware-general/Documentation/APPNOTE-6.3.9.TXT):

"This entry in the Local header MUST include BOTH original and compressed file size fields."

The emphasis is not mine, it's in the original document. 7Zip does not follow this. Decisions on whether to write out the uncompressed size, compressed size, or position information into the extended field are made based on the size of the data for each field in isolation. It will happily emit an extended field which contains, for example, just the position, or potentially just the compressed size (if it was inflated beyond the original size). This is not standards compliant, and other tools could misinterpret this information as a result.

This change modifies the behaviour to always include both the original and compressed file size fields into the Zip64 extended information extra field, as required by the standard.