### PR TITLE
Allow users of the SDK to decide about hardware-accelerated CRC

### DIFF
--- a/C/7zCrc.c
+++ b/C/7zCrc.c
@@ -9,7 +9,7 @@
 // for debug:
 // #define __ARM_FEATURE_CRC32 1
 
-#ifdef __ARM_FEATURE_CRC32
+#if defined(__ARM_FEATURE_CRC32) && !defined(Z7_NO_CRC_HW_FORCE)
 // #pragma message("__ARM_FEATURE_CRC32")
 #define Z7_CRC_HW_FORCE
 #endif
@@ -233,9 +233,9 @@ Z7_DIAGNOSTIC_IGNORE_END_RESERVED_MACRO_IDENTIFIER
 #endif // defined(Z7_CRC_HW_USE)
 #endif // MY_CPU_LE
 
-
-
 #ifndef Z7_CRC_HW_FORCE
+
+unsigned g_Crc_Algo;
 
 #if defined(Z7_CRC_HW_USE) || defined(Z7_CRC_UPDATE_T1_FUNC_NAME)
 /*
@@ -243,7 +243,6 @@ typedef UInt32 (Z7_FASTCALL *Z7_CRC_UPDATE_WITH_TABLE_FUNC)
     (UInt32 v, const void *data, size_t size, const UInt32 *table);
 Z7_CRC_UPDATE_WITH_TABLE_FUNC g_CrcUpdate;
 */
-static unsigned g_Crc_Algo;
 #if (!defined(MY_CPU_LE) && !defined(MY_CPU_BE))
 static unsigned g_Crc_Be;
 #endif

--- a/C/7zCrc.h
+++ b/C/7zCrc.h
@@ -9,6 +9,7 @@
 EXTERN_C_BEGIN
 
 extern UInt32 g_CrcTable[];
+extern unsigned g_Crc_Algo;
 
 /* Call CrcGenerateTable one time before other CRC functions */
 void Z7_FASTCALL CrcGenerateTable(void);


### PR DESCRIPTION
It's slightly helpful for fuzzers to be able to disable CRC checks. This was previously done in Chromium by overriding g_CrcTable, but hardware-accelerated CRC breaks that. This PR would allow Chromium to define Z7_NO_CRC_HW_FORCE to instead leave hardware acceleration dependent on g_Crc_Algo.

See also https://crrev.com/c/6619906.