### PR TITLE
SSE2 implementation for LzFind_SaturSub()

### DIFF
--- a/C/LzFind.c
+++ b/C/LzFind.c
@@ -598,7 +598,7 @@ void MatchFinder_Init(void *_p)
 
 #ifdef MY_CPU_X86_OR_AMD64
   #if defined(__clang__) && (__clang_major__ >= 4) \
-    || defined(Z7_GCC_VERSION) && (Z7_GCC_VERSION >= 40701)
+    || defined(Z7_GCC_VERSION) && (Z7_GCC_VERSION >= 40900)
     // || defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1900)
 
       #define USE_LZFIND_SATUR_SUB_128
@@ -612,6 +612,12 @@ void MatchFinder_Init(void *_p)
     #if (_MSC_VER >= 1900)
       #define USE_LZFIND_SATUR_SUB_256
     #endif
+  #endif
+
+  #ifdef MY_CPU_SSE2
+  // x86[-64] doesn't have integer satur ops instructions (thus slow if not vectorized)
+  // Since all x86-64 CPUs support SSE2, we can use SSE2 as a baseline implementation.
+    #include <immintrin.h>
   #endif
 
 #elif defined(MY_CPU_ARM64) \
@@ -777,6 +783,28 @@ void
 Z7_FASTCALL
 LzFind_SaturSub_32(UInt32 subValue, CLzRef *items, const CLzRef *lim)
 {
+// This SSE2 implementation is taken from clang >=11 opt result.
+// GCC can't do it in a clean way. MSVC can't even vectorize it.
+#ifdef MY_CPU_SSE2
+  const __m128i sub2 = _mm_set_epi32((Int32)subValue, (Int32)subValue, (Int32)subValue, (Int32)subValue);
+  const __m128i sign2 = _mm_set_epi32(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  const __m128i cmp2 = _mm_xor_si128(sub2, sign2);
+
+  // by reversing the sign (adding 0x80000000), we flip the strict order of signed/unsigned number as well.
+#define SASUB_SSE2_RSIGN(v) _mm_xor_si128(v, sign2)
+  // so we can use signed compare on unsigned numbers with their sign reversed.
+#define SASUB_SSE2_CMPGT(v) _mm_cmpgt_epi32(SASUB_SSE2_RSIGN(v), cmp2)
+  // the mask can be used to select like (c ? a : b), but here since b is 0, then we just use (a & c)
+#define SASUB_SSE2_v(v) _mm_and_si128(_mm_sub_epi32(v, sub2), SASUB_SSE2_CMPGT(v))
+#define SASUB_SSE2(i) *(__m128i *)(void *)(items + (i) * 4) = SASUB_SSE2_v(*(const __m128i *)(const void *)(items + (i) * 4));
+  Z7_PRAGMA_OPT_DISABLE_LOOP_UNROLL_VECTORIZE
+  do
+  {
+    SASUB_SSE2(0)  SASUB_SSE2(1)  items += 2 * 4;
+    SASUB_SSE2(0)  SASUB_SSE2(1)  items += 2 * 4;
+  }
+  while (items != lim);
+#else
   Z7_PRAGMA_OPT_DISABLE_LOOP_UNROLL_VECTORIZE
   do
   {
@@ -786,6 +814,7 @@ LzFind_SaturSub_32(UInt32 subValue, CLzRef *items, const CLzRef *lim)
     SASUB_32(0)  SASUB_32(1)  items += 2;
   }
   while (items != lim);
+#endif
 }
 
 #endif


### PR DESCRIPTION
x86[-64] doesn't have integer saturating arithmetic instructions (thus slow if not vectorized), since all x86-64 CPUs support SSE2, we can use SSE2 as a baseline implementation.

This implmentation is taken from clang's optimization result, and gcc/msvc can't optimize it this way, [see here for a comparison on godbolt](https://godbolt.org/z/KqPnWcWvc).

It also contains a minor fix to fix minimal gcc version to compile (without globally enabling `SSE4.1/AVX2` but use the `target` GCC extension). I think the old value `GCC 4.7.1` was there because [AVX2 support is added in GCC 4.7](https://gcc.gnu.org/gcc-4.7/changes.html#targets), but starting from [GCC 4.9, it is now possible to call x86 intrinsics from select functions in a file that are tagged with the corresponding target attribute without having to compile the entire file with the `-mxxx` option.](https://gcc.gnu.org/gcc-4.9/changes.html#x86).

Technically GCC 4.7 and 4.8 don't have the `target` feature in x86 intrinsic headers and don't allow including per-instruction-extension-set header directly, code like below in `<?mmintrin.h>` is only available since GCC 4.9.

```
#ifndef __AVX2__
#pragma GCC push_options
#pragma GCC target("avx2")
#define __DISABLE_AVX2__
#endif /* __AVX2__ */

// The contents

#ifdef __DISABLE_AVX2__
#undef __DISABLE_AVX2__
#pragma GCC pop_options
#endif /* __DISABLE_AVX2__ */
```
