### PR TITLE
Fix symbolic link target extraction in CPIO handler

### DIFF
--- a/CPP/7zip/Archive/CpioHandler.cpp
+++ b/CPP/7zip/Archive/CpioHandler.cpp
@@ -927,7 +927,7 @@ Z7_COM7F_IMF(CHandler::GetProperty(UInt32 index, PROPID propID, PROPVARIANT *val
         {
 #ifdef _WIN32
           UString u;
-          ConvertUTF8ToUnicode(item.Name, u);
+          ConvertUTF8ToUnicode(s, u);
 #else
           const UString u = MultiByteToUnicodeString(s, CP_OEMCP);
 #endif


### PR DESCRIPTION
Fixed bug where symbolic links were pointing to themselves instead of their correct targets on Windows. The code was probably copied from line 886 and was not adapted properly.