### PR TITLE
Add RISC-V Arch. Build Support 

### DIFF
--- a/CPP/7zip/cmpl_gcc_riscv64.mak
+++ b/CPP/7zip/cmpl_gcc_riscv64.mak
@@ -1,0 +1,3 @@
+include $(CURDIR)/../../var_gcc_riscv64.mak
+include $(CURDIR)/../../warn_gcc.mak
+include $(CURDIR)/makefile.gcc

--- a/CPP/7zip/var_gcc_riscv64.mak
+++ b/CPP/7zip/var_gcc_riscv64.mak
@@ -1,0 +1,10 @@
+PLATFORM = riscv64
+O = b/g_$(PLATFORM)
+USE_ASM =
+# IS_X64 =
+# IS_X86 =
+# IS_ARM64 =
+MY_ARCH ?= #native or -march=riscv64
+CROSS_COMPILE ?=
+CC  = $(CROSS_COMPILE)gcc
+CXX = $(CROSS_COMPILE)g++


### PR DESCRIPTION
TL;DR
Added the native riscv build files.  I've tested the setup on [Milk-V Pioneer Box](https://milkv.io/pioneer). Please let me know if requires any additional changes. 

I'm Akif from @[10xEngineers](https://10xengineers.ai/).  I'm mainly working on increasing the SW support for [RISC-V ](https://github.com/riscv)and with that intension I'm creating this PR, hoping to get this merged and have release from ip7z for riscv too. 

I was also hopping to setup the CI but I don't see any .workflow files in this repo, so, just adding the build files for now, please let me know how the release works would love to also help in that.

---

### Host Details 

```
akif@pioneer-1:~/projects$ lscpu
Architecture:           riscv64
  Byte Order:           Little Endian
CPU(s):                 64
  On-line CPU(s) list:  0-63
Vendor ID:              0x5b7
  Model name:           -
    CPU family:         0x0
    Model:              0x0
    Thread(s) per core: 1
    Core(s) per socket: 64
    Socket(s):          1
NUMA:                   
  NUMA node(s):         4
  NUMA node0 CPU(s):    1-8,16-23
  NUMA node1 CPU(s):    0,9-15,24-31
  NUMA node2 CPU(s):    32-39,48-55
  NUMA node3 CPU(s):    40-47,56-63
  ```
  
 ### Build Instructions/Flow
 ```
 git clone ... && cd 7zip
 make -C CPP/7zip/Bundles/Alone -f ../../cmpl_gcc_riscv64.mak -j"$(nproc)" 
```

and tested 7z, 7za, 7zr like this:
```
(
  echo "Starting build at $(date)"
  for i in CPP/7zip/Bundles/{Alone,Alone7z,Format7zF,SFXCon} CPP/7zip/UI/Console; do
    echo
    echo "Building bundle: $i"
    make -C "$i" -f ../../cmpl_gcc_riscv64.mak -j"$(nproc)" || { echo "Build failed in $i"; exit 1; }
  done
  echo "Build loop completed successfully at $(date)"
) >> logs.txt 2>&1
```

Attaching the logs..

```
Starting build at Mon Sep  1 04:55:13 PM PKT 2025

Building bundle: CPP/7zip/Bundles/Alone
make: Entering directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Alone'
mkdir -p b/g_riscv64
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zCrc.o ../../../../C/7zCrc.c
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zCrcOpt.o ../../../../C/7zCrcOpt.c
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zStream.o ../../../../C/7zStream.c
..
..
..

g++      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC       -o b/g_riscv64/UserInputUtils.o ../../UI/Console/UserInputUtils.cpp
g++ -o b/g_riscv64/7za -s  -DNDEBUG     -z noexecstack  b/g_riscv64/7zCrc.o b/g_riscv64/7zCrcOpt.o b/g_riscv64/7zStream.o b/g_riscv64/Aes.o b/g_riscv64/AesOpt.o b/g_riscv64/Alloc.o b/g_riscv64/Bcj2.o b/g_riscv64/Bcj2Enc.o b/g_riscv64/Bra.o b/g_riscv64/Bra86.o b/g_riscv64/BraIA64.o b/g_riscv64/BwtSort.o b/g_riscv64/CpuArch.o b/g_riscv64/Delta.o b/g_riscv64/HuffEnc.o b/g_riscv64/LzFind.o b/g_riscv64/Lzma2Dec.o b/g_riscv64/Lzma2DecMt.o b/g_riscv64/Lzma2Enc.o b/g_riscv64/LzmaDec.o b/g_riscv64/LzmaEnc.o b/g_riscv64/MtCoder.o b/g_riscv64/MtDec.o b/g_riscv64/Ppmd7.o b/g_riscv64/Ppmd7Dec.o b/g_riscv64/Ppmd7Enc.o b/g_riscv64/Ppmd8.o b/g_riscv64/Ppmd8Dec.o b/g_riscv64/Ppmd8Enc.o b/g_riscv64/Sha1.o b/g_riscv64/Sha1Opt.o b/g_riscv64/Sha256.o b/g_riscv64/Sha256Opt.o b/g_riscv64/Sort.o b/g_riscv64/SwapBytes.o b/g_riscv64/Xxh64.o b/g_riscv64/Xz.o b/g_riscv64/XzDec.o b/g_riscv64/XzEnc.o b/g_riscv64/XzIn.o b/g_riscv64/XzCrc64.o b/g_riscv64/XzCrc64Opt.o b/g_riscv64/ZstdDec.o  b/g_riscv64/LzFindMt.o b/g_riscv64/LzFindOpt.o b/g_riscv64/Threads.o b/g_riscv64/MemBlocks.o b/g_riscv64/OutMemStream.o b/g_riscv64/ProgressMt.o b/g_riscv64/StreamBinder.o b/g_riscv64/Synchronization.o b/g_riscv64/VirtThread.o  b/g_riscv64/MyWindows.o  b/g_riscv64/CommandLineParser.o b/g_riscv64/CRC.o b/g_riscv64/CrcReg.o b/g_riscv64/DynLimBuf.o b/g_riscv64/IntToString.o b/g_riscv64/ListFileUtils.o b/g_riscv64/LzFindPrepare.o b/g_riscv64/MyString.o b/g_riscv64/MyVector.o b/g_riscv64/NewHandler.o b/g_riscv64/Sha1Prepare.o b/g_riscv64/Sha1Reg.o b/g_riscv64/Sha256Prepare.o b/g_riscv64/Sha256Reg.o b/g_riscv64/StdInStream.o b/g_riscv64/StdOutStream.o b/g_riscv64/StringConvert.o b/g_riscv64/StringToInt.o b/g_riscv64/UTFConvert.o b/g_riscv64/Wildcard.o b/g_riscv64/Xxh64Reg.o b/g_riscv64/XzCrc64Init.o b/g_riscv64/XzCrc64Reg.o  b/g_riscv64/ErrorMsg.o b/g_riscv64/FileDir.o b/g_riscv64/FileFind.o b/g_riscv64/FileIO.o b/g_riscv64/FileLink.o b/g_riscv64/FileName.o b/g_riscv64/PropVariant.o b/g_riscv64/PropVariantConv.o b/g_riscv64/PropVariantUtils.o b/g_riscv64/System.o b/g_riscv64/SystemInfo.o b/g_riscv64/TimeUtils.o  b/g_riscv64/Bcj2Coder.o b/g_riscv64/Bcj2Register.o b/g_riscv64/BcjCoder.o b/g_riscv64/BcjRegister.o b/g_riscv64/BitlDecoder.o b/g_riscv64/BranchMisc.o b/g_riscv64/BranchRegister.o b/g_riscv64/ByteSwap.o b/g_riscv64/BZip2Crc.o b/g_riscv64/BZip2Decoder.o b/g_riscv64/BZip2Encoder.o b/g_riscv64/BZip2Register.o b/g_riscv64/CopyCoder.o b/g_riscv64/CopyRegister.o b/g_riscv64/Deflate64Register.o b/g_riscv64/DeflateDecoder.o b/g_riscv64/DeflateEncoder.o b/g_riscv64/DeflateRegister.o b/g_riscv64/DeltaFilter.o b/g_riscv64/ImplodeDecoder.o b/g_riscv64/Lzma2Decoder.o b/g_riscv64/Lzma2Encoder.o b/g_riscv64/Lzma2Register.o b/g_riscv64/LzmaDecoder.o b/g_riscv64/LzmaEncoder.o b/g_riscv64/LzmaRegister.o b/g_riscv64/LzOutWindow.o b/g_riscv64/LzxDecoder.o b/g_riscv64/PpmdDecoder.o b/g_riscv64/PpmdEncoder.o b/g_riscv64/PpmdRegister.o b/g_riscv64/PpmdZip.o b/g_riscv64/QuantumDecoder.o b/g_riscv64/ShrinkDecoder.o b/g_riscv64/XzDecoder.o b/g_riscv64/XzEncoder.o b/g_riscv64/ZstdDecoder.o  b/g_riscv64/7zAes.o b/g_riscv64/7zAesRegister.o b/g_riscv64/HmacSha1.o b/g_riscv64/MyAes.o b/g_riscv64/MyAesReg.o b/g_riscv64/Pbkdf2HmacSha1.o b/g_riscv64/RandGen.o b/g_riscv64/WzAes.o b/g_riscv64/ZipCrypto.o b/g_riscv64/ZipStrong.o  b/g_riscv64/CreateCoder.o b/g_riscv64/CWrappers.o b/g_riscv64/FilePathAutoRename.o b/g_riscv64/FileStreams.o b/g_riscv64/InBuffer.o b/g_riscv64/InOutTempBuffer.o b/g_riscv64/FilterCoder.o b/g_riscv64/LimitedStreams.o b/g_riscv64/MethodId.o b/g_riscv64/MethodProps.o b/g_riscv64/MultiOutStream.o b/g_riscv64/OffsetStream.o b/g_riscv64/OutBuffer.o b/g_riscv64/ProgressUtils.o b/g_riscv64/PropId.o b/g_riscv64/StreamObjects.o b/g_riscv64/StreamUtils.o b/g_riscv64/UniqBlocks.o  b/g_riscv64/Bz2Handler.o b/g_riscv64/GzHandler.o b/g_riscv64/LzmaHandler.o b/g_riscv64/SplitHandler.o b/g_riscv64/XzHandler.o b/g_riscv64/ZstdHandler.o  b/g_riscv64/CoderMixer2.o b/g_riscv64/DummyOutStream.o b/g_riscv64/HandlerOut.o b/g_riscv64/InStreamWithCRC.o b/g_riscv64/ItemNameUtils.o b/g_riscv64/MultiStream.o b/g_riscv64/OutStreamWithCRC.o b/g_riscv64/ParseProperties.o  b/g_riscv64/7zCompressionMode.o b/g_riscv64/7zDecode.o b/g_riscv64/7zEncode.o b/g_riscv64/7zExtract.o b/g_riscv64/7zFolderInStream.o b/g_riscv64/7zHandler.o b/g_riscv64/7zHandlerOut.o b/g_riscv64/7zHeader.o b/g_riscv64/7zIn.o b/g_riscv64/7zOut.o b/g_riscv64/7zProperties.o b/g_riscv64/7zRegister.o b/g_riscv64/7zSpecStream.o b/g_riscv64/7zUpdate.o  b/g_riscv64/CabBlockInStream.o b/g_riscv64/CabHandler.o b/g_riscv64/CabHeader.o b/g_riscv64/CabIn.o b/g_riscv64/CabRegister.o  b/g_riscv64/TarHandler.o b/g_riscv64/TarHandlerOut.o b/g_riscv64/TarHeader.o b/g_riscv64/TarIn.o b/g_riscv64/TarOut.o b/g_riscv64/TarUpdate.o b/g_riscv64/TarRegister.o  b/g_riscv64/ZipAddCommon.o b/g_riscv64/ZipHandler.o b/g_riscv64/ZipHandlerOut.o b/g_riscv64/ZipIn.o b/g_riscv64/ZipItem.o b/g_riscv64/ZipOut.o b/g_riscv64/ZipUpdate.o b/g_riscv64/ZipRegister.o  b/g_riscv64/ArchiveCommandLine.o b/g_riscv64/ArchiveExtractCallback.o b/g_riscv64/ArchiveOpenCallback.o b/g_riscv64/Bench.o b/g_riscv64/DefaultName.o b/g_riscv64/EnumDirItems.o b/g_riscv64/Extract.o b/g_riscv64/ExtractingFilePath.o b/g_riscv64/HashCalc.o b/g_riscv64/LoadCodecs.o b/g_riscv64/OpenArchive.o b/g_riscv64/PropIDUtils.o b/g_riscv64/SetProperties.o b/g_riscv64/SortUtils.o b/g_riscv64/TempFiles.o b/g_riscv64/Update.o b/g_riscv64/UpdateAction.o b/g_riscv64/UpdateCallback.o b/g_riscv64/UpdatePair.o b/g_riscv64/UpdateProduce.o  b/g_riscv64/BenchCon.o b/g_riscv64/ConsoleClose.o b/g_riscv64/ExtractCallbackConsole.o b/g_riscv64/HashCon.o b/g_riscv64/List.o b/g_riscv64/Main.o b/g_riscv64/MainAr.o b/g_riscv64/OpenCallbackConsole.o b/g_riscv64/PercentPrinter.o b/g_riscv64/UpdateCallbackConsole.o b/g_riscv64/UserInputUtils.o    -lpthread -ldl
make: Leaving directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Alone'

Building bundle: CPP/7zip/Bundles/Alone7z
make: Entering directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Alone7z'
mkdir -p b/g_riscv64
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zCrc.o ../../../../C/7zCrc.c
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zCrcOpt.o ../../../../C/7zCrcOpt.c
gcc      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zStream.o ../../../../C/7zStream.c
..
..
..
g++      -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC       -o b/g_riscv64/BenchCon.o ../../UI/Console/BenchCon.cpp
g++ -o b/g_riscv64/7zr -s  -DNDEBUG     -z noexecstack  b/g_riscv64/7zCrc.o b/g_riscv64/7zCrcOpt.o b/g_riscv64/7zStream.o b/g_riscv64/Aes.o b/g_riscv64/AesOpt.o b/g_riscv64/Alloc.o b/g_riscv64/Bcj2.o b/g_riscv64/Bcj2Enc.o b/g_riscv64/Bra.o b/g_riscv64/Bra86.o b/g_riscv64/BraIA64.o b/g_riscv64/CpuArch.o b/g_riscv64/Delta.o b/g_riscv64/LzFind.o b/g_riscv64/Lzma2Dec.o b/g_riscv64/Lzma2DecMt.o b/g_riscv64/Lzma2Enc.o b/g_riscv64/LzmaDec.o b/g_riscv64/LzmaEnc.o b/g_riscv64/MtCoder.o b/g_riscv64/MtDec.o b/g_riscv64/Sha256.o b/g_riscv64/Sha256Opt.o b/g_riscv64/SwapBytes.o b/g_riscv64/Xz.o b/g_riscv64/XzDec.o b/g_riscv64/XzEnc.o b/g_riscv64/XzIn.o b/g_riscv64/XzCrc64.o b/g_riscv64/XzCrc64Opt.o  b/g_riscv64/LzFindMt.o b/g_riscv64/LzFindOpt.o b/g_riscv64/Threads.o b/g_riscv64/StreamBinder.o b/g_riscv64/VirtThread.o  b/g_riscv64/MyWindows.o  b/g_riscv64/CommandLineParser.o b/g_riscv64/CRC.o b/g_riscv64/CrcReg.o b/g_riscv64/DynLimBuf.o b/g_riscv64/IntToString.o b/g_riscv64/ListFileUtils.o b/g_riscv64/LzFindPrepare.o b/g_riscv64/MyString.o b/g_riscv64/MyVector.o b/g_riscv64/NewHandler.o b/g_riscv64/Sha256Prepare.o b/g_riscv64/Sha256Reg.o b/g_riscv64/StdInStream.o b/g_riscv64/StdOutStream.o b/g_riscv64/StringConvert.o b/g_riscv64/StringToInt.o b/g_riscv64/UTFConvert.o b/g_riscv64/Wildcard.o b/g_riscv64/XzCrc64Init.o b/g_riscv64/XzCrc64Reg.o  b/g_riscv64/ErrorMsg.o b/g_riscv64/FileDir.o b/g_riscv64/FileFind.o b/g_riscv64/FileIO.o b/g_riscv64/FileLink.o b/g_riscv64/FileName.o b/g_riscv64/PropVariant.o b/g_riscv64/PropVariantConv.o b/g_riscv64/System.o b/g_riscv64/SystemInfo.o b/g_riscv64/TimeUtils.o  b/g_riscv64/Bcj2Coder.o b/g_riscv64/Bcj2Register.o b/g_riscv64/BcjCoder.o b/g_riscv64/BcjRegister.o b/g_riscv64/BranchMisc.o b/g_riscv64/BranchRegister.o b/g_riscv64/ByteSwap.o b/g_riscv64/CopyCoder.o b/g_riscv64/CopyRegister.o b/g_riscv64/DeltaFilter.o b/g_riscv64/Lzma2Decoder.o b/g_riscv64/Lzma2Encoder.o b/g_riscv64/Lzma2Register.o b/g_riscv64/LzmaDecoder.o b/g_riscv64/LzmaEncoder.o b/g_riscv64/LzmaRegister.o b/g_riscv64/XzDecoder.o b/g_riscv64/XzEncoder.o  b/g_riscv64/7zAes.o b/g_riscv64/7zAesRegister.o b/g_riscv64/MyAes.o b/g_riscv64/MyAesReg.o b/g_riscv64/RandGen.o  b/g_riscv64/CreateCoder.o b/g_riscv64/CWrappers.o b/g_riscv64/FilePathAutoRename.o b/g_riscv64/FileStreams.o b/g_riscv64/InBuffer.o b/g_riscv64/InOutTempBuffer.o b/g_riscv64/FilterCoder.o b/g_riscv64/LimitedStreams.o b/g_riscv64/MethodId.o b/g_riscv64/MethodProps.o b/g_riscv64/MultiOutStream.o b/g_riscv64/OffsetStream.o b/g_riscv64/OutBuffer.o b/g_riscv64/ProgressUtils.o b/g_riscv64/PropId.o b/g_riscv64/StreamObjects.o b/g_riscv64/StreamUtils.o b/g_riscv64/UniqBlocks.o  b/g_riscv64/LzmaHandler.o b/g_riscv64/SplitHandler.o b/g_riscv64/XzHandler.o  b/g_riscv64/CoderMixer2.o b/g_riscv64/DummyOutStream.o b/g_riscv64/HandlerOut.o b/g_riscv64/InStreamWithCRC.o b/g_riscv64/ItemNameUtils.o b/g_riscv64/MultiStream.o b/g_riscv64/OutStreamWithCRC.o b/g_riscv64/ParseProperties.o  b/g_riscv64/7zCompressionMode.o b/g_riscv64/7zDecode.o b/g_riscv64/7zEncode.o b/g_riscv64/7zExtract.o b/g_riscv64/7zFolderInStream.o b/g_riscv64/7zHandler.o b/g_riscv64/7zHandlerOut.o b/g_riscv64/7zHeader.o b/g_riscv64/7zIn.o b/g_riscv64/7zOut.o b/g_riscv64/7zProperties.o b/g_riscv64/7zRegister.o b/g_riscv64/7zSpecStream.o b/g_riscv64/7zUpdate.o  b/g_riscv64/ArchiveCommandLine.o b/g_riscv64/ArchiveExtractCallback.o b/g_riscv64/ArchiveOpenCallback.o b/g_riscv64/Bench.o b/g_riscv64/DefaultName.o b/g_riscv64/EnumDirItems.o b/g_riscv64/Extract.o b/g_riscv64/ExtractingFilePath.o b/g_riscv64/HashCalc.o b/g_riscv64/LoadCodecs.o b/g_riscv64/OpenArchive.o b/g_riscv64/PropIDUtils.o b/g_riscv64/SetProperties.o b/g_riscv64/SortUtils.o b/g_riscv64/TempFiles.o b/g_riscv64/Update.o b/g_riscv64/UpdateAction.o b/g_riscv64/UpdateCallback.o b/g_riscv64/UpdatePair.o b/g_riscv64/UpdateProduce.o  b/g_riscv64/BenchCon.o b/g_riscv64/ConsoleClose.o b/g_riscv64/ExtractCallbackConsole.o b/g_riscv64/HashCon.o b/g_riscv64/List.o b/g_riscv64/Main.o b/g_riscv64/MainAr.o b/g_riscv64/OpenCallbackConsole.o b/g_riscv64/PercentPrinter.o b/g_riscv64/UpdateCallbackConsole.o b/g_riscv64/UserInputUtils.o    -lpthread -ldl
make: Leaving directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Alone7z'

Building bundle: CPP/7zip/Bundles/Format7zF
make: Entering directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Format7zF'
mkdir -p b/g_riscv64
gcc  -DZ7_EXTERNAL_CODECS     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC  -fPIC -o b/g_riscv64/7zBuf2.o ../../../../C/7zBuf2.c
gcc  -DZ7_EXTERNAL_CODECS     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC  -fPIC -o b/g_riscv64/7zCrc.o ../../../../C/7zCrc.c
..
..
..
g++  -DZ7_EXTERNAL_CODECS     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -fPIC    -o b/g_riscv64/Rar20Crypto.o ../../Crypto/Rar20Crypto.cpp
g++ -o b/g_riscv64/7z.so -s  -shared -fPIC -DNDEBUG     -z noexecstack  b/g_riscv64/7zBuf2.o b/g_riscv64/7zCrc.o b/g_riscv64/7zCrcOpt.o b/g_riscv64/7zStream.o b/g_riscv64/Aes.o b/g_riscv64/AesOpt.o b/g_riscv64/Alloc.o b/g_riscv64/Bcj2.o b/g_riscv64/Bcj2Enc.o b/g_riscv64/Blake2s.o b/g_riscv64/Bra.o b/g_riscv64/Bra86.o b/g_riscv64/BraIA64.o b/g_riscv64/BwtSort.o b/g_riscv64/CpuArch.o b/g_riscv64/Delta.o b/g_riscv64/HuffEnc.o b/g_riscv64/LzFind.o b/g_riscv64/Lzma2Dec.o b/g_riscv64/Lzma2DecMt.o b/g_riscv64/Lzma2Enc.o b/g_riscv64/LzmaDec.o b/g_riscv64/LzmaEnc.o b/g_riscv64/Md5.o b/g_riscv64/MtCoder.o b/g_riscv64/MtDec.o b/g_riscv64/Ppmd7.o b/g_riscv64/Ppmd7Dec.o b/g_riscv64/Ppmd7aDec.o b/g_riscv64/Ppmd7Enc.o b/g_riscv64/Ppmd8.o b/g_riscv64/Ppmd8Dec.o b/g_riscv64/Ppmd8Enc.o b/g_riscv64/Sha1.o b/g_riscv64/Sha1Opt.o b/g_riscv64/Sha256.o b/g_riscv64/Sha256Opt.o b/g_riscv64/Sha3.o b/g_riscv64/Sha512.o b/g_riscv64/Sha512Opt.o b/g_riscv64/Sort.o b/g_riscv64/SwapBytes.o b/g_riscv64/Xxh64.o b/g_riscv64/Xz.o b/g_riscv64/XzDec.o b/g_riscv64/XzEnc.o b/g_riscv64/XzIn.o b/g_riscv64/XzCrc64.o b/g_riscv64/XzCrc64Opt.o b/g_riscv64/ZstdDec.o  b/g_riscv64/LzFindMt.o b/g_riscv64/LzFindOpt.o b/g_riscv64/Threads.o b/g_riscv64/MemBlocks.o b/g_riscv64/OutMemStream.o b/g_riscv64/ProgressMt.o b/g_riscv64/StreamBinder.o b/g_riscv64/Synchronization.o b/g_riscv64/VirtThread.o  b/g_riscv64/CRC.o b/g_riscv64/CrcReg.o b/g_riscv64/DynLimBuf.o b/g_riscv64/IntToString.o b/g_riscv64/LzFindPrepare.o b/g_riscv64/Md5Reg.o b/g_riscv64/MyMap.o b/g_riscv64/MyString.o b/g_riscv64/MyVector.o b/g_riscv64/MyXml.o b/g_riscv64/NewHandler.o b/g_riscv64/Sha1Prepare.o b/g_riscv64/Sha1Reg.o b/g_riscv64/Sha256Prepare.o b/g_riscv64/Sha256Reg.o b/g_riscv64/Sha3Reg.o b/g_riscv64/Sha512Prepare.o b/g_riscv64/Sha512Reg.o b/g_riscv64/StringConvert.o b/g_riscv64/StringToInt.o b/g_riscv64/UTFConvert.o b/g_riscv64/Wildcard.o b/g_riscv64/Xxh64Reg.o b/g_riscv64/XzCrc64Init.o b/g_riscv64/XzCrc64Reg.o  b/g_riscv64/FileDir.o b/g_riscv64/FileFind.o b/g_riscv64/FileIO.o b/g_riscv64/FileName.o b/g_riscv64/PropVariant.o b/g_riscv64/PropVariantConv.o b/g_riscv64/PropVariantUtils.o b/g_riscv64/System.o b/g_riscv64/TimeUtils.o  b/g_riscv64/CreateCoder.o b/g_riscv64/CWrappers.o b/g_riscv64/InBuffer.o b/g_riscv64/InOutTempBuffer.o b/g_riscv64/FilterCoder.o b/g_riscv64/LimitedStreams.o b/g_riscv64/LockedStream.o b/g_riscv64/MethodId.o b/g_riscv64/MethodProps.o b/g_riscv64/OffsetStream.o b/g_riscv64/OutBuffer.o b/g_riscv64/ProgressUtils.o b/g_riscv64/PropId.o b/g_riscv64/StreamObjects.o b/g_riscv64/StreamUtils.o b/g_riscv64/UniqBlocks.o  b/g_riscv64/ApfsHandler.o b/g_riscv64/ApmHandler.o b/g_riscv64/ArHandler.o b/g_riscv64/ArjHandler.o b/g_riscv64/Base64Handler.o b/g_riscv64/Bz2Handler.o b/g_riscv64/ComHandler.o b/g_riscv64/CpioHandler.o b/g_riscv64/CramfsHandler.o b/g_riscv64/DeflateProps.o b/g_riscv64/DmgHandler.o b/g_riscv64/ElfHandler.o b/g_riscv64/ExtHandler.o b/g_riscv64/FatHandler.o b/g_riscv64/FlvHandler.o b/g_riscv64/GzHandler.o b/g_riscv64/GptHandler.o b/g_riscv64/HandlerCont.o b/g_riscv64/HfsHandler.o b/g_riscv64/IhexHandler.o b/g_riscv64/LpHandler.o b/g_riscv64/LzhHandler.o b/g_riscv64/LzmaHandler.o b/g_riscv64/MachoHandler.o b/g_riscv64/MbrHandler.o b/g_riscv64/MslzHandler.o b/g_riscv64/MubHandler.o b/g_riscv64/NtfsHandler.o b/g_riscv64/PeHandler.o b/g_riscv64/PpmdHandler.o b/g_riscv64/QcowHandler.o b/g_riscv64/RpmHandler.o b/g_riscv64/SparseHandler.o b/g_riscv64/SplitHandler.o b/g_riscv64/SquashfsHandler.o b/g_riscv64/SwfHandler.o b/g_riscv64/UefiHandler.o b/g_riscv64/VdiHandler.o b/g_riscv64/VhdHandler.o b/g_riscv64/VhdxHandler.o b/g_riscv64/VmdkHandler.o b/g_riscv64/XarHandler.o b/g_riscv64/XzHandler.o b/g_riscv64/ZHandler.o b/g_riscv64/ZstdHandler.o  b/g_riscv64/CoderMixer2.o b/g_riscv64/DummyOutStream.o b/g_riscv64/FindSignature.o b/g_riscv64/InStreamWithCRC.o b/g_riscv64/ItemNameUtils.o b/g_riscv64/MultiStream.o b/g_riscv64/OutStreamWithCRC.o b/g_riscv64/OutStreamWithSha1.o b/g_riscv64/HandlerOut.o b/g_riscv64/ParseProperties.o  b/g_riscv64/7zCompressionMode.o b/g_riscv64/7zDecode.o b/g_riscv64/7zEncode.o b/g_riscv64/7zExtract.o b/g_riscv64/7zFolderInStream.o b/g_riscv64/7zHandler.o b/g_riscv64/7zHandlerOut.o b/g_riscv64/7zHeader.o b/g_riscv64/7zIn.o b/g_riscv64/7zOut.o b/g_riscv64/7zProperties.o b/g_riscv64/7zSpecStream.o b/g_riscv64/7zUpdate.o b/g_riscv64/7zRegister.o  b/g_riscv64/CabBlockInStream.o b/g_riscv64/CabHandler.o b/g_riscv64/CabHeader.o b/g_riscv64/CabIn.o b/g_riscv64/CabRegister.o  b/g_riscv64/ChmHandler.o b/g_riscv64/ChmIn.o   b/g_riscv64/IsoHandler.o b/g_riscv64/IsoHeader.o b/g_riscv64/IsoIn.o b/g_riscv64/IsoRegister.o  b/g_riscv64/NsisDecode.o b/g_riscv64/NsisHandler.o b/g_riscv64/NsisIn.o b/g_riscv64/NsisRegister.o  b/g_riscv64/RarHandler.o b/g_riscv64/Rar5Handler.o  b/g_riscv64/TarHandler.o b/g_riscv64/TarHandlerOut.o b/g_riscv64/TarHeader.o b/g_riscv64/TarIn.o b/g_riscv64/TarOut.o b/g_riscv64/TarUpdate.o b/g_riscv64/TarRegister.o  b/g_riscv64/UdfHandler.o b/g_riscv64/UdfIn.o  b/g_riscv64/WimHandler.o b/g_riscv64/WimHandlerOut.o b/g_riscv64/WimIn.o b/g_riscv64/WimRegister.o  b/g_riscv64/ZipAddCommon.o b/g_riscv64/ZipHandler.o b/g_riscv64/ZipHandlerOut.o b/g_riscv64/ZipIn.o b/g_riscv64/ZipItem.o b/g_riscv64/ZipOut.o b/g_riscv64/ZipUpdate.o b/g_riscv64/ZipRegister.o  b/g_riscv64/Bcj2Coder.o b/g_riscv64/Bcj2Register.o b/g_riscv64/BcjCoder.o b/g_riscv64/BcjRegister.o b/g_riscv64/BitlDecoder.o b/g_riscv64/BranchMisc.o b/g_riscv64/BranchRegister.o b/g_riscv64/ByteSwap.o b/g_riscv64/BZip2Crc.o b/g_riscv64/BZip2Decoder.o b/g_riscv64/BZip2Encoder.o b/g_riscv64/BZip2Register.o b/g_riscv64/CopyCoder.o b/g_riscv64/CopyRegister.o b/g_riscv64/Deflate64Register.o b/g_riscv64/DeflateDecoder.o b/g_riscv64/DeflateEncoder.o b/g_riscv64/DeflateRegister.o b/g_riscv64/DeltaFilter.o b/g_riscv64/ImplodeDecoder.o b/g_riscv64/LzfseDecoder.o b/g_riscv64/LzhDecoder.o b/g_riscv64/Lzma2Decoder.o b/g_riscv64/Lzma2Encoder.o b/g_riscv64/Lzma2Register.o b/g_riscv64/LzmaDecoder.o b/g_riscv64/LzmaEncoder.o b/g_riscv64/LzmaRegister.o b/g_riscv64/LzmsDecoder.o b/g_riscv64/LzOutWindow.o b/g_riscv64/LzxDecoder.o b/g_riscv64/PpmdDecoder.o b/g_riscv64/PpmdEncoder.o b/g_riscv64/PpmdRegister.o b/g_riscv64/PpmdZip.o b/g_riscv64/QuantumDecoder.o b/g_riscv64/ShrinkDecoder.o b/g_riscv64/XpressDecoder.o b/g_riscv64/XzDecoder.o b/g_riscv64/XzEncoder.o b/g_riscv64/ZlibDecoder.o b/g_riscv64/ZlibEncoder.o b/g_riscv64/ZDecoder.o b/g_riscv64/ZstdDecoder.o  b/g_riscv64/Rar1Decoder.o b/g_riscv64/Rar2Decoder.o b/g_riscv64/Rar3Decoder.o b/g_riscv64/Rar3Vm.o b/g_riscv64/Rar5Decoder.o b/g_riscv64/RarCodecsRegister.o  b/g_riscv64/7zAes.o b/g_riscv64/7zAesRegister.o b/g_riscv64/HmacSha1.o b/g_riscv64/HmacSha256.o b/g_riscv64/MyAes.o b/g_riscv64/MyAesReg.o b/g_riscv64/Pbkdf2HmacSha1.o b/g_riscv64/RandGen.o b/g_riscv64/WzAes.o b/g_riscv64/ZipCrypto.o b/g_riscv64/ZipStrong.o  b/g_riscv64/Rar20Crypto.o b/g_riscv64/Rar5Aes.o b/g_riscv64/RarAes.o   b/g_riscv64/ArchiveExports.o b/g_riscv64/DllExports2.o  b/g_riscv64/CodecExports.o  b/g_riscv64/MyWindows.o    -lpthread -ldl
make: Leaving directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/Format7zF'

Building bundle: CPP/7zip/Bundles/SFXCon
make: Entering directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/SFXCon'
mkdir -p b/g_riscv64
gcc  -DZ7_EXTRACT_ONLY -DZ7_NO_READ_FROM_CODER -DZ7_SFX     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/7zStream.o ../../../../C/7zStream.c
gcc  -DZ7_EXTRACT_ONLY -DZ7_NO_READ_FROM_CODER -DZ7_SFX     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/Alloc.o ../../../../C/Alloc.c
..
..
..
g++  -DZ7_EXTRACT_ONLY -DZ7_NO_READ_FROM_CODER -DZ7_SFX     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC       -o b/g_riscv64/ExtractCallbackConsole.o ../../UI/Console/ExtractCallbackConsole.cpp
g++  -DZ7_EXTRACT_ONLY -DZ7_NO_READ_FROM_CODER -DZ7_SFX     -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC       -o b/g_riscv64/SfxCon.o ../../Bundles/SFXCon/SfxCon.cpp
g++ -o b/g_riscv64/7zCon -s  -DNDEBUG     -z noexecstack  b/g_riscv64/7zStream.o b/g_riscv64/Alloc.o b/g_riscv64/Bcj2.o b/g_riscv64/Bra.o b/g_riscv64/Bra86.o b/g_riscv64/BraIA64.o b/g_riscv64/CpuArch.o b/g_riscv64/Delta.o b/g_riscv64/Lzma2Dec.o b/g_riscv64/Lzma2DecMt.o b/g_riscv64/LzmaDec.o b/g_riscv64/MtDec.o b/g_riscv64/Ppmd7.o b/g_riscv64/Ppmd7Dec.o b/g_riscv64/Sha256.o b/g_riscv64/Sha256Opt.o b/g_riscv64/7zCrc.o b/g_riscv64/7zCrcOpt.o b/g_riscv64/Aes.o b/g_riscv64/AesOpt.o  b/g_riscv64/StreamBinder.o b/g_riscv64/Synchronization.o b/g_riscv64/VirtThread.o b/g_riscv64/Threads.o  b/g_riscv64/MyWindows.o  b/g_riscv64/CommandLineParser.o b/g_riscv64/CRC.o b/g_riscv64/IntToString.o b/g_riscv64/MyString.o b/g_riscv64/MyVector.o b/g_riscv64/NewHandler.o b/g_riscv64/Sha256Prepare.o b/g_riscv64/StdInStream.o b/g_riscv64/StdOutStream.o b/g_riscv64/StringConvert.o b/g_riscv64/UTFConvert.o b/g_riscv64/Wildcard.o  b/g_riscv64/ErrorMsg.o b/g_riscv64/FileDir.o b/g_riscv64/FileFind.o b/g_riscv64/FileIO.o b/g_riscv64/FileName.o b/g_riscv64/PropVariant.o b/g_riscv64/PropVariantConv.o b/g_riscv64/System.o b/g_riscv64/TimeUtils.o  b/g_riscv64/Bcj2Coder.o b/g_riscv64/Bcj2Register.o b/g_riscv64/BcjCoder.o b/g_riscv64/BcjRegister.o b/g_riscv64/BranchMisc.o b/g_riscv64/BranchRegister.o b/g_riscv64/CopyCoder.o b/g_riscv64/CopyRegister.o b/g_riscv64/DeltaFilter.o b/g_riscv64/Lzma2Decoder.o b/g_riscv64/Lzma2Register.o b/g_riscv64/LzmaDecoder.o b/g_riscv64/LzmaRegister.o b/g_riscv64/PpmdDecoder.o b/g_riscv64/PpmdRegister.o  b/g_riscv64/7zAes.o b/g_riscv64/7zAesRegister.o b/g_riscv64/MyAes.o  b/g_riscv64/CreateCoder.o b/g_riscv64/CWrappers.o b/g_riscv64/FilePathAutoRename.o b/g_riscv64/FileStreams.o b/g_riscv64/InBuffer.o b/g_riscv64/FilterCoder.o b/g_riscv64/LimitedStreams.o b/g_riscv64/OutBuffer.o b/g_riscv64/ProgressUtils.o b/g_riscv64/PropId.o b/g_riscv64/StreamObjects.o b/g_riscv64/StreamUtils.o  b/g_riscv64/SplitHandler.o  b/g_riscv64/CoderMixer2.o b/g_riscv64/ItemNameUtils.o b/g_riscv64/MultiStream.o b/g_riscv64/OutStreamWithCRC.o  b/g_riscv64/7zDecode.o b/g_riscv64/7zExtract.o b/g_riscv64/7zHandler.o b/g_riscv64/7zIn.o b/g_riscv64/7zRegister.o  b/g_riscv64/ArchiveExtractCallback.o b/g_riscv64/ArchiveOpenCallback.o b/g_riscv64/DefaultName.o b/g_riscv64/Extract.o b/g_riscv64/ExtractingFilePath.o b/g_riscv64/LoadCodecs.o b/g_riscv64/OpenArchive.o b/g_riscv64/PropIDUtils.o  b/g_riscv64/ConsoleClose.o b/g_riscv64/ExtractCallbackConsole.o b/g_riscv64/List.o b/g_riscv64/MainAr.o b/g_riscv64/OpenCallbackConsole.o b/g_riscv64/PercentPrinter.o b/g_riscv64/UserInputUtils.o  b/g_riscv64/SfxCon.o    -lpthread -ldl
make: Leaving directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/Bundles/SFXCon'

Building bundle: CPP/7zip/UI/Console
make: Entering directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/UI/Console'
mkdir -p b/g_riscv64
gcc    -DZ7_EXTERNAL_CODECS   -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/Alloc.o ../../../../C/Alloc.c
gcc    -DZ7_EXTERNAL_CODECS   -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/CpuArch.o ../../../../C/CpuArch.c
gcc    -DZ7_EXTERNAL_CODECS   -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC   -o b/g_riscv64/Sort.o ../../../../C/Sort.c
..
..
..

g++    -DZ7_EXTERNAL_CODECS   -O2 -c -Werror -Wall -Wextra -Waddress -Waggressive-loop-optimizations -Wattributes -Wcast-align -Wcomment -Wdiv-by-zero -Wformat-contains-nul -Winit-self -Wint-to-pointer-cast -Wunused -Wunused-macros  -Wbool-compare  -Wduplicated-cond  -Wbool-operation -Wconversion -Wdangling-else -Wduplicated-branches -Wimplicit-fallthrough=5 -Wint-in-bool-context -Wmaybe-uninitialized -Wmisleading-indentation  -Wcast-align=strict -Wmissing-attributes -Waddress-of-packed-member  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fPIC       -o b/g_riscv64/List.o ../../UI/Console/List.cpp
g++ -o b/g_riscv64/7z -s  -DNDEBUG     -z noexecstack b/g_riscv64/Alloc.o b/g_riscv64/CpuArch.o b/g_riscv64/Sort.o b/g_riscv64/7zCrc.o b/g_riscv64/7zCrcOpt.o  b/g_riscv64/Synchronization.o b/g_riscv64/Threads.o  b/g_riscv64/CommandLineParser.o b/g_riscv64/CRC.o b/g_riscv64/CrcReg.o b/g_riscv64/DynLimBuf.o b/g_riscv64/IntToString.o b/g_riscv64/ListFileUtils.o b/g_riscv64/NewHandler.o b/g_riscv64/StdInStream.o b/g_riscv64/StdOutStream.o b/g_riscv64/MyString.o b/g_riscv64/StringConvert.o b/g_riscv64/StringToInt.o b/g_riscv64/UTFConvert.o b/g_riscv64/MyVector.o b/g_riscv64/Wildcard.o  b/g_riscv64/DLL.o b/g_riscv64/ErrorMsg.o b/g_riscv64/FileDir.o b/g_riscv64/FileFind.o b/g_riscv64/FileIO.o b/g_riscv64/FileLink.o b/g_riscv64/FileName.o b/g_riscv64/PropVariant.o b/g_riscv64/PropVariantConv.o b/g_riscv64/System.o b/g_riscv64/SystemInfo.o b/g_riscv64/TimeUtils.o  b/g_riscv64/MyWindows.o  b/g_riscv64/CopyCoder.o  b/g_riscv64/ItemNameUtils.o  b/g_riscv64/CreateCoder.o b/g_riscv64/CWrappers.o b/g_riscv64/FilePathAutoRename.o b/g_riscv64/FileStreams.o b/g_riscv64/InBuffer.o b/g_riscv64/InOutTempBuffer.o b/g_riscv64/FilterCoder.o b/g_riscv64/LimitedStreams.o b/g_riscv64/MethodId.o b/g_riscv64/MethodProps.o b/g_riscv64/MultiOutStream.o b/g_riscv64/OffsetStream.o b/g_riscv64/OutBuffer.o b/g_riscv64/ProgressUtils.o b/g_riscv64/PropId.o b/g_riscv64/StreamObjects.o b/g_riscv64/StreamUtils.o b/g_riscv64/UniqBlocks.o  b/g_riscv64/ArchiveCommandLine.o b/g_riscv64/ArchiveExtractCallback.o b/g_riscv64/ArchiveOpenCallback.o b/g_riscv64/Bench.o b/g_riscv64/DefaultName.o b/g_riscv64/EnumDirItems.o b/g_riscv64/Extract.o b/g_riscv64/ExtractingFilePath.o b/g_riscv64/HashCalc.o b/g_riscv64/LoadCodecs.o b/g_riscv64/OpenArchive.o b/g_riscv64/PropIDUtils.o b/g_riscv64/SetProperties.o b/g_riscv64/SortUtils.o b/g_riscv64/TempFiles.o b/g_riscv64/Update.o b/g_riscv64/UpdateAction.o b/g_riscv64/UpdateCallback.o b/g_riscv64/UpdatePair.o b/g_riscv64/UpdateProduce.o  b/g_riscv64/BenchCon.o b/g_riscv64/ConsoleClose.o b/g_riscv64/ExtractCallbackConsole.o b/g_riscv64/HashCon.o b/g_riscv64/List.o b/g_riscv64/Main.o b/g_riscv64/MainAr.o b/g_riscv64/OpenCallbackConsole.o b/g_riscv64/PercentPrinter.o b/g_riscv64/UpdateCallbackConsole.o b/g_riscv64/UserInputUtils.o    -lpthread -ldl
make: Leaving directory '/home/akif/projects/rvv-porting/7zip-dev/CPP/7zip/UI/Console'
Build loop completed successfully at Mon Sep  1 04:56:27 PM PKT 2025
```

And after successful build I see the binaries like these:
```
akif@pioneer-1:~/projects/rvv-porting/7zip-dev$ ls -l $BIN_7Z $BIN_7ZA $BIN_7ZR $BIN_7ZSO  2>/dev/null 
-rwxr-xr-x 1 akif internal_users  953568 Sep  1 16:55 CPP/7zip/Bundles/Alone7z/b/g_riscv64/7zr
-rwxr-xr-x 1 akif internal_users 1346816 Sep  1 16:55 CPP/7zip/Bundles/Alone/b/g_riscv64/7za
-rwxr-xr-x 1 akif internal_users 2434312 Sep  1 16:56 CPP/7zip/Bundles/Format7zF/b/g_riscv64/7z.so
-rwxr-xr-x 1 akif internal_users  556240 Sep  1 16:56 CPP/7zip/UI/Console/b/g_riscv64/7z

```
and 

```
akif@pioneer-1:~/projects/rvv-porting/7zip-dev$ readelf -h $BIN_7Z $BIN_7ZA $BIN_7ZR $BIN_7ZSO

File: CPP/7zip/UI/Console/b/g_riscv64/7z
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Position-Independent Executable file)
  Machine:                           RISC-V
  Version:                           0x1
  Entry point address:               0x11e68
  Start of program headers:          64 (bytes into file)
  Start of section headers:          554384 (bytes into file)
  Flags:                             0x5, RVC, double-float ABI
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         11
  Size of section headers:           64 (bytes)
  Number of section headers:         29
  Section header string table index: 28

File: CPP/7zip/Bundles/Alone/b/g_riscv64/7za
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Position-Independent Executable file)
  Machine:                           RISC-V
  Version:                           0x1
  Entry point address:               0x27e74
  Start of program headers:          64 (bytes into file)
  Start of section headers:          1344960 (bytes into file)
  Flags:                             0x5, RVC, double-float ABI
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         11
  Size of section headers:           64 (bytes)
  Number of section headers:         29
  Section header string table index: 28

File: CPP/7zip/Bundles/Alone7z/b/g_riscv64/7zr
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Position-Independent Executable file)
  Machine:                           RISC-V
  Version:                           0x1
  Entry point address:               0x1de98
  Start of program headers:          64 (bytes into file)
  Start of section headers:          951712 (bytes into file)
  Flags:                             0x5, RVC, double-float ABI
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         11
  Size of section headers:           64 (bytes)
  Number of section headers:         29
  Section header string table index: 28

File: CPP/7zip/Bundles/Format7zF/b/g_riscv64/7z.so
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Shared object file)
  Machine:                           RISC-V
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          64 (bytes into file)
  Start of section headers:          2432648 (bytes into file)
  Flags:                             0x5, RVC, double-float ABI
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         8
  Size of section headers:           64 (bytes)
  Number of section headers:         26
  Section header string table index: 25

```
